### PR TITLE
fix(jpc): expose COM segment content

### DIFF
--- a/jpc/src/lib.rs
+++ b/jpc/src/lib.rs
@@ -1221,8 +1221,8 @@ impl ImageAndTileSizeMarkerSegment {
     }
 }
 
-#[derive(Debug)]
-enum CommentRegistrationValue {
+#[derive(Debug, PartialEq)]
+pub enum CommentRegistrationValue {
     // General use (binary values)
     Binary,
 
@@ -1258,11 +1258,11 @@ pub struct CommentMarkerSegment {
 }
 
 impl CommentMarkerSegment {
-    fn registration_value(&self) -> CommentRegistrationValue {
+    pub fn registration_value(&self) -> CommentRegistrationValue {
         CommentRegistrationValue::new(self.registration_value)
     }
 
-    fn comment_utf8(&self) -> Result<&str, str::Utf8Error> {
+    pub fn comment_utf8(&self) -> Result<&str, str::Utf8Error> {
         str::from_utf8(&self.comment)
     }
 }

--- a/jpc/tests/parse_tests.rs
+++ b/jpc/tests/parse_tests.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::BufReader, path::Path};
 
-use jpc::{decode_jpc};
+use jpc::{CommentRegistrationValue, decode_jpc};
 
 #[test]
 fn test_blue() {
@@ -41,4 +41,11 @@ fn test_blue() {
     assert_eq!(siz.vertical_separation(0).unwrap(), 1);
     assert_eq!(siz.vertical_separation(1).unwrap(), 1);
     assert_eq!(siz.vertical_separation(2).unwrap(), 1);
+
+    assert!(header.comment_marker_segment().is_some());
+    let com = header.comment_marker_segment().as_ref().unwrap();
+    assert_eq!(com.registration_value(), CommentRegistrationValue::Binary);
+    assert!(com.comment_utf8().is_ok());
+    assert_eq!(com.comment_utf8().unwrap(), "Created by OpenJPEG version 2.5.0");
+
 }


### PR DESCRIPTION
The methods were there, just not available.