### PR TITLE
fix(jpc): correct handling of COM segment

### DIFF
--- a/jpc/tests/parse_tests.rs
+++ b/jpc/tests/parse_tests.rs
@@ -45,9 +45,9 @@ fn test_blue() {
     assert_eq!(siz.vertical_separation(1).unwrap(), 1);
     assert_eq!(siz.vertical_separation(2).unwrap(), 1);
 
-    assert!(header.comment_marker_segment().is_some());
-    let com = header.comment_marker_segment().as_ref().unwrap();
-    assert_eq!(com.registration_value(), CommentRegistrationValue::Binary);
+    assert_eq!(header.comment_marker_segments().len(), 1);
+    let com = header.comment_marker_segments().first().unwrap();
+    assert_eq!(com.registration_value(), CommentRegistrationValue::Latin);
     assert!(com.comment_utf8().is_ok());
     assert_eq!(com.comment_utf8().unwrap(), "Created by OpenJPEG version 2.5.0");
 


### PR DESCRIPTION
BREAKING CHANGE: This segment is repeatable, so we need a Vec, not an Option.

Also, the Rcom values are 0 and 1 (not 1 and 2). Identified with jpylyzer which showed:

```
        <com>
            <lcom>37</lcom>
            <rcom>ISO/IEC 8859-15 (Latin)</rcom>
            <comment>Created by OpenJPEG version 2.5.0</comment>
        </com>
```