### PR TITLE
minor clippy fixes for acronym casing

### DIFF
--- a/jp2/src/lib.rs
+++ b/jp2/src/lib.rs
@@ -117,8 +117,8 @@ enum BoxTypes {
     DefaultDisplayResolution,
     ContiguousCodestream,
     IntellectualProperty,
-    XML,
-    UUID,
+    Xml,
+    Uuid,
     UUIDInfo,
     UUIDList,
     DataEntryURL,
@@ -150,9 +150,9 @@ impl BoxTypes {
 
             BOX_TYPE_CONTIGUOUS_CODESTREAM => BoxTypes::ContiguousCodestream,
             BOX_TYPE_INTELLECTUAL_PROPERTY => BoxTypes::IntellectualProperty,
-            BOX_TYPE_XML => BoxTypes::XML,
+            BOX_TYPE_XML => BoxTypes::Xml,
 
-            BOX_TYPE_UUID => BoxTypes::UUID,
+            BOX_TYPE_UUID => BoxTypes::Uuid,
             BOX_TYPE_UUID_INFO => BoxTypes::UUIDInfo,
             BOX_TYPE_UUID_LIST => BoxTypes::UUIDList,
             BOX_TYPE_DATA_ENTRY_URL => BoxTypes::DataEntryURL,
@@ -2764,7 +2764,7 @@ pub fn decode_jp2<R: io::Read + io::Seek>(
                     reader.stream_position()
                 );
             }
-            BoxTypes::XML => {
+            BoxTypes::Xml => {
                 let mut xml_box = XMLBox {
                     length: box_length,
                     offset: reader.stream_position()?,
@@ -2775,7 +2775,7 @@ pub fn decode_jp2<R: io::Read + io::Seek>(
                 xml_boxes.push(xml_box);
                 info!("XMLBox finish at {:?}", reader.stream_position()?);
             }
-            BoxTypes::UUID => {
+            BoxTypes::Uuid => {
                 let mut uuid_box = UUIDBox::default();
                 uuid_box.length = box_length;
                 uuid_box.offset = reader.stream_position()?;

--- a/jpeg2000/src/main.rs
+++ b/jpeg2000/src/main.rs
@@ -50,7 +50,7 @@ enum SubCommand {
     Decode(Decode),
 
     /// Encode .jp2 container or .jpc codestream file to JPXML document (stdout)
-    JPXML(JPXML),
+    JpXml(JpXml),
 }
 
 #[derive(Parser)]
@@ -60,7 +60,7 @@ struct Decode {
 }
 
 #[derive(Parser)]
-struct JPXML {
+struct JpXml {
     /// Path to .jp2 file
     path: String,
 
@@ -129,7 +129,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
-        SubCommand::JPXML(c) => {
+        SubCommand::JpXml(c) => {
             let path = Path::new(&c.path);
             let filename = path.file_name().and_then(OsStr::to_str).unwrap_or_default();
             let extension = path.extension().and_then(OsStr::to_str).unwrap_or_default();


### PR DESCRIPTION
Resolves #15 

I went back and forth a bit with UUID. Eventually leaned to `Uuid` for consistency with the uuid crate.