### PR TITLE
jp2: separate out bit depth and signedness for BPC result

### DIFF
--- a/jp2/tests/parse_tests.rs
+++ b/jp2/tests/parse_tests.rs
@@ -39,8 +39,7 @@ fn test_jp2_file(filename: &str, expected_len: u64) {
     assert_eq!(image_header_box.colourspace_unknown(), 0);
     assert_eq!(image_header_box.intellectual_property(), 0);
     assert_eq!(image_header_box.components_bits(), 16);
-    // TODO: add this API
-    // assert_eq!(image_header_box.values_are_signed(), false);
+    assert_eq!(image_header_box.values_are_signed(), false);
 
     assert!(header_box.bits_per_component_box.is_none());
 


### PR DESCRIPTION
See Part 1 Section I.5.3.1 for the image header box, and the BPC text inline and in Table I.6.

Also upgraded the documentation to work in `rust doc`

Resolves #29.