### PR TITLE
chore(ci): add rustfmt check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,24 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v4
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
-      - run: cargo test --verbose --workspace
-  
+      - name: Fetch Repository
+        uses: actions/checkout@v5
+      - name: Install toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Check build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose --workspace
+
+  format_lint:
+    name: Check formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v5
+      - name: Install toolchain with rustfmt
+        run: rustup update stable && rustup default stable && rustup component add rustfmt
+      - name: Check rust format
+        run: cargo fmt --all --check
+


### PR DESCRIPTION
This extends the CI to check formatting.

These kinds of linting checks can be a bit annoying, but I think its worth it to push consistency in the longer term.