### PR TITLE
Fix COD coding style and precinct size extraction

### DIFF
--- a/jpc/src/lib.rs
+++ b/jpc/src/lib.rs
@@ -285,29 +285,26 @@ impl CodingStyleDefault {
     fn new(value: u8) -> Vec<CodingStyleDefault> {
         let mut coding_styles: Vec<CodingStyleDefault> = vec![];
 
-        if value & 0b_0000_0001 > 0 {
+        if value & 0b11111001 == 0 {
             coding_styles.push(CodingStyleDefault::EntropyCoderWithPrecinctsDefined);
-        } else {
+        } else if value & 0b11111001 == 0b0001 {
             coding_styles.push(CodingStyleDefault::EntropyCoderWithPrecincts);
         }
 
-        if value & 0b_0000_0010 > 0 {
-            coding_styles.push(CodingStyleDefault::SOP);
-        } else {
+        if value & 0b11111010 == 0 {
             coding_styles.push(CodingStyleDefault::NoSOP);
+        } else if value & 0b11111010 == 0b10 {
+            coding_styles.push(CodingStyleDefault::SOP);
         }
 
-        if value & 0b_0000_0100 > 0 {
-            coding_styles.push(CodingStyleDefault::EPH);
-        } else {
+        if value & 0b11111100 == 0 {
             coding_styles.push(CodingStyleDefault::NoEPH);
+        } else if value & 0b11111100 == 0b0100 {
+            coding_styles.push(CodingStyleDefault::EPH);
         }
 
-        if value != 0 {
-            coding_styles.push(CodingStyleDefault::Reserved {
-                value: value >> 3 << 3,
-            });
-        }
+        // TODO implement ISO/IEC 15444-1 Table A.13 reservered
+        // TODO implement ISO/IEC 15444-2 Table A.5 extensions
 
         coding_styles
     }

--- a/jpc/tests/packet_marker_tests.rs
+++ b/jpc/tests/packet_marker_tests.rs
@@ -1,8 +1,8 @@
 use std::{fs::File, io::BufReader, path::Path};
 
 use jpc::{
-    decode_jpc, CodingBlockStyle, CommentRegistrationValue, MultipleComponentTransformation,
-    ProgressionOrder, TransformationFilter,
+    decode_jpc, CodingBlockStyle, CodingStyleDefault, CommentRegistrationValue,
+    MultipleComponentTransformation, ProgressionOrder, TransformationFilter,
 };
 
 #[test]
@@ -56,6 +56,14 @@ fn test_eph() {
     let cod = header.coding_style_marker_segment();
     // Scod
     assert_eq!(cod.coding_style(), 4);
+    assert_eq!(
+        cod.coding_styles(),
+        vec![
+            CodingStyleDefault::EntropyCoderWithPrecinctsDefined,
+            CodingStyleDefault::NoSOP,
+            CodingStyleDefault::EPH
+        ]
+    );
     // SGcod
     assert_eq!(cod.progression_order(), ProgressionOrder::RLLCPP);
     assert_eq!(cod.no_layers(), 1);


### PR DESCRIPTION
@bradh I think this fixes #22. The reserved detection for coding style is now broken.