### PR TITLE
fix(jp2): correct identifier() result for capture resolution box

### DIFF
--- a/jp2/src/lib.rs
+++ b/jp2/src/lib.rs
@@ -2585,7 +2585,7 @@ impl CaptureResolutionBox {
 impl JBox for CaptureResolutionBox {
     // The type of a Capture Resolution box shall be ‘resc’ (0x7265 7363).
     fn identifier(&self) -> BoxType {
-        BOX_TYPE_DEFAULT_DISPLAY_RESOLUTION
+        BOX_TYPE_CAPTURE_RESOLUTION
     }
 
     fn length(&self) -> u64 {

--- a/jp2/tests/parse_tests.rs
+++ b/jp2/tests/parse_tests.rs
@@ -965,8 +965,10 @@ fn test_res_boxes() {
     assert!(header_box.channel_definition_box.is_none());
     assert!(header_box.resolution_box.is_some());
     let res = header_box.resolution_box.as_ref().unwrap();
+    assert_eq!(res.identifier(), [b'r', b'e', b's', b' ']);
     assert!(res.capture_resolution_box().is_some());
     let resc = res.capture_resolution_box().as_ref().unwrap();
+    assert_eq!(resc.identifier(), [b'r', b'e', b's', b'c']);
     /* From jpylyzer:
         <vRcN>20</vRcN>
         <vRcD>1</vRcD>
@@ -986,6 +988,7 @@ fn test_res_boxes() {
 
     assert!(res.default_display_resolution_box().is_some());
     let resd = res.default_display_resolution_box().as_ref().unwrap();
+    assert_eq!(resd.identifier(), [b'r', b'e', b's', b'd']);
     /* From jpylyzer:
         <vRdN>300</vRdN>
         <vRdD>1</vRdD>


### PR DESCRIPTION
Adds test cases for related boxes to back-stop the change.