### PR TITLE
jp2000: add j2k as a supported codestream suffix

### DIFF
--- a/jpeg2000/src/main.rs
+++ b/jpeg2000/src/main.rs
@@ -91,7 +91,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
             let file = File::open(path)?;
 
-            match extension {
+            match extension.to_ascii_lowercase().as_str() {
                 "jp2" => {
                     let mut reader = BufReader::new(file);
 
@@ -114,7 +114,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                         };
                     }
                 }
-                "jpc" | "j2c" => {
+                "jpc" | "j2c" | "j2k" => {
                     let mut reader = BufReader::new(file);
                     if let Err(error) = decode_jpc(&mut reader) {
                         return Err(JP2000Error::DecodingCodestream {


### PR DESCRIPTION
Also make comparison case-insensitive.

From 15444-1 N.3.2: "File extension(s): j2c, J2C, j2k, J2K"

From 15444-1 I.2.1 on jp2: "(readers should allow mixed case for the alphabetic characters)"