### PR TITLE
Add handling of reserved markers

### DIFF
--- a/jpc/src/lib.rs
+++ b/jpc/src/lib.rs
@@ -2799,6 +2799,29 @@ impl ContiguousCodestream {
                         reader.seek(io::SeekFrom::Current(-2))?;
                         break;
                     }
+
+                    // Reserved markers
+                    // ITU-T H.800 or ISO/IEC 15444-1 2024, Section A.1.3 and Table A.1
+                    MarkerSymbol([0xff, 0x30])
+                    | MarkerSymbol([0xff, 0x31])
+                    | MarkerSymbol([0xff, 0x32])
+                    | MarkerSymbol([0xff, 0x33])
+                    | MarkerSymbol([0xff, 0x34])
+                    | MarkerSymbol([0xff, 0x35])
+                    | MarkerSymbol([0xff, 0x36])
+                    | MarkerSymbol([0xff, 0x37])
+                    | MarkerSymbol([0xff, 0x38])
+                    | MarkerSymbol([0xff, 0x39])
+                    | MarkerSymbol([0xff, 0x3A])
+                    | MarkerSymbol([0xff, 0x3B])
+                    | MarkerSymbol([0xff, 0x3C])
+                    | MarkerSymbol([0xff, 0x3D])
+                    | MarkerSymbol([0xff, 0x3E])
+                    | MarkerSymbol([0xff, 0x3F]) => {
+                        // Reserved as marker only, not a segment
+                        info!("Skipping marker: {:?}", marker_type);
+                    }
+
                     _ => {
                         log::error!("unexpected marker type: {marker_type:?}");
                         return Err(CodestreamError::MarkerUnexpected {

--- a/jpc/tests/compliance.rs
+++ b/jpc/tests/compliance.rs
@@ -32,7 +32,7 @@ fn test_parse_p0_j2k_files() {
     let files = [
         // (Expect parse?, file_name)
         (true, "./input/conformance/p0_01.j2k"),
-        (false, "./input/conformance/p0_02.j2k"),
+        (true, "./input/conformance/p0_02.j2k"),
         (false, "./input/conformance/p0_03.j2k"),
         (true, "./input/conformance/p0_04.j2k"),
         (false, "./input/conformance/p0_05.j2k"),


### PR DESCRIPTION
According to T.800 section A.1.3, there are some reserved markers that should be skipped. 0xFF30 appears in conformance test p0_02.j2k.